### PR TITLE
Add 'LanguageVersion' annotation support to 'ScriptsTestsBase'

### DIFF
--- a/testsrc/org/mozilla/javascript/drivers/LanguageVersion.java
+++ b/testsrc/org/mozilla/javascript/drivers/LanguageVersion.java
@@ -1,0 +1,18 @@
+package org.mozilla.javascript.drivers;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * Intended to be used as an optional annotation for subclasses
+ * of {@link org.mozilla.javascript.drivers.ScriptTestsBase}.
+ * Sets the language version of test's script execution context.
+ */
+@Target(TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LanguageVersion {
+    int value();
+}

--- a/testsrc/org/mozilla/javascript/drivers/ScriptTestsBase.java
+++ b/testsrc/org/mozilla/javascript/drivers/ScriptTestsBase.java
@@ -31,11 +31,19 @@ public abstract class ScriptTestsBase {
     assertNotNull(anno);
     String suiteName = anno.value();
 
+    int jsVersion = Context.VERSION_1_8;
+    LanguageVersion jsVersionAnnotation = this.getClass().getAnnotation(LanguageVersion.class);
+    if (jsVersionAnnotation != null) {
+      jsVersion = jsVersionAnnotation.value();
+      Context.checkLanguageVersion(jsVersion);
+    }
+
     FileReader script = null;
     Context cx = Context.enter();
     try {
       script = new FileReader(suiteName);
       cx.setOptimizationLevel(optLevel);
+      cx.setLanguageVersion(jsVersion);
 
       Global global = new Global(cx);
 


### PR DESCRIPTION
For arrow functions tests that I'm working on it would be useful to be able to set language level to at least 1.7, because default version doesn't allow to use `let` declarations (strangely, `const` declarations are allowed even for 1.0) and they are important for some tests.

I see two possible ways to "fix" that:
- change default version to 1.7 for `ScriptsTestsBase`. This is done for Rhino's JsShell*, but it's really not flexible enough as we might come up with tests that will require lower or higher versions.
- add some way of parametrization of `ScirptsTestsBase`'s sub-classes. And because we already use annotations for passing test's script path, it would be reasonable to use annotation for this purpose too.

In this PR I've combined those two: I've added optional `LanguageVersion` annotation support to `ScriptsTestsBase` that will allow to set language version for every test class separately  _and_ changed default version to 1.7.

What do you think?

\* -- which led to about one hour of crazy debugging: the same code worked perfectly in `master` branch and threw SyntaxError in `arrow-functions`. In the end, it turned out that because in master I was using JsShell to test code, it had language version set to 1.7, while `ScriptsTestsBase` runs code with `Context.VERSION_DEFAULT`.
