### PR TITLE
Don't swallow empty lines in doctest; split lines on Mac/Windows/Unix.

### DIFF
--- a/toolsrc/org/mozilla/javascript/tools/shell/Global.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Global.java
@@ -413,7 +413,7 @@ public class Global extends ImporterTopLevel
                           String sourceName, int lineNumber)
     {
         doctestCanonicalizations = new HashMap<String,String>();
-        String[] lines = session.split("[\n\r]+");
+        String[] lines = session.split("\r\n?|\n");
         String prompt0 = this.prompts[0].trim();
         String prompt1 = this.prompts[1].trim();
         int testCount = 0;


### PR DESCRIPTION
Use a line-splitting regexp that works on Mac, Windows, and Unix, without
swallowing blank lines.
